### PR TITLE
Add action for building registry-viewer docker image

### DIFF
--- a/.github/workflows/Docker.yaml
+++ b/.github/workflows/Docker.yaml
@@ -1,0 +1,17 @@
+name: Docker
+
+# Triggers the workflow on push or pull request events but only for the main branch
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Check if docker image build is working
+        run: docker build -f Dockerfile .


### PR DESCRIPTION
**What does this PR do / why we need it**:
Adds a GitHub action for building the registry viewer's dockerfile. Since the devfile registry indirectly consumes this dockerfile, it would be wise to build it in PR builds.

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:

N/A

**How to test changes / Special notes to the reviewer**:

N/A