### PR TITLE
Add DEVFILE_VIEWER_ROOT and DEVFILE_COMMUNITY_HOST as build time args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 # Rebuild the source code only when needed
+ARG DEVFILE_VIEWER_ROOT
+ARG DEVFILE_COMMUNITY_HOST
 FROM registry.access.redhat.com/ubi8/nodejs-14-minimal AS builder
 USER root
 WORKDIR /app


### PR DESCRIPTION
**What does this PR do / why we need it**:
When the devfile registry index server builds the registry viewer, we need to set `DEVFILE_VIEWER_ROOT` and `DEVFILE_COMMUNITY_HOST` as build-time args:
```
docker build -t registry-viewer --target builder --build-arg DEVFILE_VIEWER_ROOT=/viewer --build-arg DEVFILE_COMMUNITY_HOST=false $buildfolder/registry-viewer
```

To enable this, we need to add the following to the top of the registry viewer's dockerfile:
```
ARG DEVFILE_VIEWER_ROOT
ARG DEVFILE_COMMUNITY_HOST
```

If these build-time args are unset, it doesn't affect the registry viewer's build.

