### PR TITLE
Move ARGs into build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Rebuild the source code only when needed
+FROM registry.access.redhat.com/ubi8/nodejs-14-minimal AS builder
 ARG DEVFILE_VIEWER_ROOT
 ARG DEVFILE_COMMUNITY_HOST
-FROM registry.access.redhat.com/ubi8/nodejs-14-minimal AS builder
 USER root
 WORKDIR /app
 RUN npm install -g yarn


### PR DESCRIPTION
**What does this PR do / why we need it**:
The ARGs that we use in the build stage need to be below the FROM if we want to properly use them
