### PR TITLE
Don't trigger repository dispatch for workflow runs

### DIFF
--- a/.github/workflows/push-changes.yaml
+++ b/.github/workflows/push-changes.yaml
@@ -3,12 +3,6 @@ name: Push Changes
 on:
   push:
     branches: [main]
-  workflow_run:
-    workflows:
-      - Cypress
-      - Docker
-    types:
-      - completed
 
 jobs:
   dispatch:


### PR DESCRIPTION
The repository dispatch should only run after pushes to main.