### PR TITLE
Add css for long description

### DIFF
--- a/src/components/DevfilePage/DevfilePageHeader/DevfilePageHeader.module.css
+++ b/src/components/DevfilePage/DevfilePageHeader/DevfilePageHeader.module.css
@@ -87,3 +87,10 @@
   width: 50%;
   margin: 2%;
 }
+
+.longDescription {
+  overflow: scroll;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+}

--- a/src/components/DevfilePage/DevfilePageHeader/DevfilePageHeader.tsx
+++ b/src/components/DevfilePage/DevfilePageHeader/DevfilePageHeader.tsx
@@ -61,7 +61,10 @@ export const DevfilePageHeader: React.FC<DevfilePageHeaderProps> = ({
               {devfile.displayName}
             </Text>
             {devfile.description && (
-              <Text data-testid="description" className={styles.basicText}>
+              <Text
+                data-testid="description"
+                className={styles.basicText + ' ' + styles.longDescription}
+              >
                 {devfile.description}
               </Text>
             )}

--- a/src/components/HomeGallery/HomeGalleryItem/HomeGalleryItem.module.css
+++ b/src/components/HomeGallery/HomeGalleryItem/HomeGalleryItem.module.css
@@ -35,3 +35,10 @@
   text-align: right;
   color: var(--pf-global--Color--200);
 }
+
+.longDescription {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}

--- a/src/components/HomeGallery/HomeGalleryItem/HomeGalleryItem.module.css
+++ b/src/components/HomeGallery/HomeGalleryItem/HomeGalleryItem.module.css
@@ -39,6 +39,6 @@
 .longDescription {
   overflow: hidden;
   display: -webkit-box;
-  -webkit-line-clamp: 2;
+  -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
 }

--- a/src/components/HomeGallery/HomeGalleryItem/HomeGalleryItem.tsx
+++ b/src/components/HomeGallery/HomeGalleryItem/HomeGalleryItem.tsx
@@ -70,7 +70,9 @@ export const HomeGalleryItem: React.FC<HomeGalleryItemProps> = ({
       </CardTitle>
       <CardBody className={styles.cardBody}>
         <TextContent>
-          <Text component={TextVariants.p}>{devfile.description}</Text>
+          <Text component={TextVariants.p} className={styles.longDescription}>
+            {devfile.description}
+          </Text>
         </TextContent>
       </CardBody>
       <CardFooter>


### PR DESCRIPTION
**What does this PR do / why we need it**:
this PR adds css for long description in main page & devfile page. 

Without this change, the main page looks like this with long description: it has a hard cut off 
<img width="318" alt="Screen Shot 2021-09-29 at 3 16 43 PM" src="https://user-images.githubusercontent.com/22285490/135493556-7c8e10d9-6b38-468b-bbe5-1fdbe2bacbba.png">

with this change,  it looks like: it will have  `...` add to the end if the description is longer than 3 lines, means that the description is too long to be shown in the main page. 
<img width="307" alt="Screen Shot 2021-09-30 at 12 49 11 PM" src="https://user-images.githubusercontent.com/22285490/135497602-a321cd1b-c902-4df6-b2e9-d21938eb2e46.png">

Without this change, the devfile page looks like this with long description:
<img width="959" alt="Screen Shot 2021-09-30 at 12 05 50 PM" src="https://user-images.githubusercontent.com/22285490/135493576-813e8c73-a20e-4746-a456-356b3e721b8b.png">


With this change, there will still have `...` added if the over 4 lines, means there are contents hidden. And user can scroll up & down to view the full description
<img width="754" alt="Screen Shot 2021-09-30 at 12 06 34 PM" src="https://user-images.githubusercontent.com/22285490/135493594-fd552c6a-4f12-4882-94ab-c07055aed504.png">

**Which issue(s) this PR fixes**:
Fixes https://github.com/devfile/api/issues/606

**PR acceptance criteria**:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

**How to test changes / Special notes to the reviewer**:
