### PR TITLE
Added html header for registry api calls and added failed download tr…

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -140,6 +140,7 @@
     "react/display-name": 0,
     "react/no-unescaped-entities": ["error", { "forbid": [">", "}"] }],
     "spaced-comment": "error",
-    "use-isnan": "error"
+    "use-isnan": "error",
+    "no-case-declarations": "off"
   }
 }

--- a/src/components/DevfilePage/DevfilePageProjects/DevfilePageProjects.tsx
+++ b/src/components/DevfilePage/DevfilePageProjects/DevfilePageProjects.tsx
@@ -75,26 +75,26 @@ export const DevfilePageProjects: React.FC<DevfilePageProjectsProps> = ({
   async function triggerDownload(project: Project): Promise<void> {
     setDownloading(true);
 
-    if (analytics) {
-      const region = getUserRegion(router.locale);
-      const { publicRuntimeConfig } = getConfig();
-
-      analytics.track(
-        'Starter Project Downloaded',
-        {
-          client: publicRuntimeConfig.segmentClientId,
-          devfile: devfile.name,
-          starterProject: project.name,
-        },
-        {
-          context: { ip: '0.0.0.0', location: { country: region } },
-          userId: analytics.user().anonymousId(),
-        },
-      );
-    }
-
     try {
       await download(project);
+
+      if (analytics) {
+        const region = getUserRegion(router.locale);
+        const { publicRuntimeConfig } = getConfig();
+
+        analytics.track(
+          'Starter Project Downloaded',
+          {
+            client: publicRuntimeConfig.segmentClientId,
+            devfile: devfile.name,
+            starterProject: project.name,
+          },
+          {
+            context: { ip: '0.0.0.0', location: { country: region } },
+            userId: analytics.user().anonymousId(),
+          },
+        );
+      }
     } catch (error) {
       if (error instanceof UnsupportedLinkError) {
         setErrorAlert({
@@ -111,6 +111,24 @@ export const DevfilePageProjects: React.FC<DevfilePageProjectsProps> = ({
             'Internal error has occurred during download. Please try again or report as issue. \n',
           alertType: 'danger',
         });
+      }
+
+      if (analytics) {
+        const region = getUserRegion(router.locale);
+        const { publicRuntimeConfig } = getConfig();
+
+        analytics.track(
+          'Starter Project Download Failed',
+          {
+            client: publicRuntimeConfig.segmentClientId,
+            devfile: devfile.name,
+            starterProject: project.name,
+          },
+          {
+            context: { ip: '0.0.0.0', location: { country: region } },
+            userId: analytics.user().anonymousId(),
+          },
+        );
       }
     }
 

--- a/src/util/server/getDevfileRegistryJSON.ts
+++ b/src/util/server/getDevfileRegistryJSON.ts
@@ -18,7 +18,9 @@ export const getRemoteJSON = async (
   url: string,
   alias: string | undefined,
 ): Promise<Devfile[]> => {
-  const res = await fetch(`${url}/index/all?icon=base64`);
+  const res = await fetch(`${url}/index/all?icon=base64`, {
+    headers: { client: 'registry-viewer' },
+  });
   const devfilesWithoutName = (await res.json()) as Devfile[];
   const devfiles = devfilesWithoutName.map((devfile: Devfile) => {
     devfile.registry = registryName;

--- a/src/util/server/getDevfileYAML.ts
+++ b/src/util/server/getDevfileYAML.ts
@@ -16,7 +16,7 @@ import { load as yamlToJSON } from 'js-yaml';
  */
 export const getRemoteYAML = async (devfileName: string, url: string): Promise<string> => {
   const res = await fetch(`${url}/devfiles/${devfileName}`, {
-    headers: { 'Accept-Type': 'text/plain' },
+    headers: { 'Accept-Type': 'text/plain', client: 'registry-viewer' },
   });
   const devfileYAML = (await res.text()) as string;
   return devfileYAML;


### PR DESCRIPTION
**What does this PR do / why we need it**:

- Adds html header for registry api calls `client: 'registry-viewer'`
- Adds failed devfile project download track event

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/651
