### PR TITLE
identify call

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "license": "EPL-2.0",
   "devDependencies": {
     "@babel/core": "^7.14.3",
-    "@types/analytics-node": "^3.1.7",
     "@types/file-saver": "^2.0.3",
     "@types/node": "^15.6.1",
     "@types/react": "^17.0.8",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -20,13 +20,23 @@ const MyApp: NextPage<AppProps> = ({ Component, pageProps }: AppProps) => {
     if (analytics) {
       const region = getUserRegion(router.locale);
       const { publicRuntimeConfig } = getConfig();
+      const anonymousId = analytics.user().anonymousId();
+      analytics.identify(
+        anonymousId,
+        {
+          id: anonymousId,
+        },
+        {
+          context: { ip: '0.0.0.0', location: { country: region } },
+        },
+      );
 
       analytics.track(
         router.asPath,
         { client: publicRuntimeConfig.segmentClientId },
         {
           context: { ip: '0.0.0.0', location: { country: region } },
-          userId: analytics.user().anonymousId(),
+          userId: anonymousId,
         },
       );
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1973,11 +1973,6 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@types/analytics-node@^3.1.7":
-  version "3.1.7"
-  resolved "https://registry.yarnpkg.com/@types/analytics-node/-/analytics-node-3.1.7.tgz#cb97c80ee505094e44a0188c3ad25f70c67e3c65"
-  integrity sha512-qoBHCXqFqC22Up8dus8YIloZ2t1f8MJx9b3E08ZBK04yJ/ai8U2WuFUnaIBiD1okw4VtuNjqKn9mgLHnLxb5OQ==
-
 "@types/aria-query@^4.2.0":
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.2.tgz#ed4e0ad92306a704f9fb132a0cfcf77486dbe2bc"


### PR DESCRIPTION
**What does this PR do / why we need it**:
Adds an identify call to the main registry viewer page to ensure the anonymous ID is tracked as a userid that gets sent to Woopra

**Which issue(s) this PR fixes**:

Fixes #?
https://github.com/devfile/api/issues/716

**PR acceptance criteria**:

- [ ] Unit Tests
- [ ] E2E Tests
- [ ] Documentation

**How to test changes / Special notes to the reviewer**:

Manually tested by modifying the build script in the registry-support repo to clone and build the local registry-viewer changes.  Deployed on CRC and tested a local instance of the viewer. 

- Verified userid was set correctly in Segment and no IPs were exposed
- Verified events in Woopra showed up with visitor IDs instead of cookie Ids
- Verified cookie info in local storage contained the traits userid and userId was not null 
